### PR TITLE
Feature/re add module node

### DIFF
--- a/lib/ruby_minifier/visitors/minify_visitor.rb
+++ b/lib/ruby_minifier/visitors/minify_visitor.rb
@@ -52,6 +52,14 @@ module RubyMinifier
         @result << ";end"
       end
 
+      def visit_module_node(node)
+        @result << "module "
+        visit(node.constant_path)
+        @result << ";"
+        visit(node.body) if node.body
+        @result << ";end"
+      end
+
       def visit_class_node(node)
         @result << "class "
         visit(node.constant_path)

--- a/test/test_ruby_minifier.rb
+++ b/test/test_ruby_minifier.rb
@@ -77,6 +77,19 @@ class TestRubyMinifier < Minitest::Test
     assert_equal expected, @minifier.minify(code)
   end
 
+  def test_module_definition
+    code = <<~RUBY
+      module Example
+        def initialize(name)
+          @name = name
+        end
+      end
+    RUBY
+
+    expected = "module Example;def initialize(name);@name=name;end;end"
+    assert_equal expected, @minifier.minify(code)
+  end
+
   def test_token_structure
     code = "puts 'hello'"
     result = Prism.lex(code)


### PR DESCRIPTION
>[!note]
I have recreated the [PR](https://github.com/ryoh827/ruby_minifier/pull/4).

With the current codebase, the following behavior occurs:

```ruby
hoge = <<~NEST
  module Hoge
     module Fuga
       class Piyo
       end
     end
   end
NEST
# => "module Hoge\n  module Fuga\n    class Piyo\n    end\n  end\nend\n"
RubyMinifier::Minifier.new.minify(hoge)
# => "HogeFugaclass Piyo;;end"
```
The module definitions are removed, so the code is not correctly minified. Therefore, we need to implement visit_module_node to achieve proper minification.